### PR TITLE
Always download the latest version of the sm-agent

### DIFF
--- a/supermaven-binary.el
+++ b/supermaven-binary.el
@@ -26,7 +26,7 @@
                 ((string-match-p "^arm64-" system-configuration) "aarch64")
                 ((string-match-p "^x86_64-" system-configuration) "x86_64")
                 (t (error "Unsupported architecture: %s" system-configuration))))
-         (url (format "https://supermaven.com/api/download-path?platform=%s&arch=%s&editor=emacs" platform arch))
+         (url (format "https://supermaven.com/api/download-path?platform=%s&arch=%s&editor=neovim" platform arch))
          (_ (supermaven-log-debug (format "Fetching binary URL: %s" url)))
          (response (with-current-buffer
                        (url-retrieve-synchronously url)
@@ -36,7 +36,7 @@
                        (json-read))))
          (download-url (gethash "downloadUrl" response))
          (_ (supermaven-log-debug (format "Download URL: %s" download-url)))
-         (binary-dir (expand-file-name ".supermaven/binary/v15" (getenv "HOME")))
+         (binary-dir (expand-file-name ".supermaven/binary" (getenv "HOME")))
          (binary-path (expand-file-name (format "sm-agent%s" (if (eq system-type 'windows-nt) ".exe" "")) binary-dir)))
 
     (unless (file-exists-p binary-dir)


### PR DESCRIPTION
The download will not download a specific version. It will always download the latest version.

This PR ...

* removes the version number from the download path
* if you want to know what version of sm-agent you are running you can run ...
``` bash
~/.supermaven/binary/sm-agent version
```

Note: There is no `sm-agent` for emacs. Means we have to download the neovim version.

Note: There is always the risk that newer versions of sm-agent will break this. We probably need to add a way to configure a version number so that we can run against older versions. #4 